### PR TITLE
terminal+client: Support reading and writing system clipboard via OSC 52

### DIFF
--- a/lib/include/ttx/clipboard.h
+++ b/lib/include/ttx/clipboard.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "dius/steady_clock.h"
+#include "ttx/features.h"
+#include "ttx/terminal/escapes/osc_52.h"
+
+namespace ttx {
+/// @brief Implementation of clipboard handling for ttx
+///
+/// This class supports a number of different simulataneous
+/// selections, each of which can be queried or set.
+class Clipboard {
+    // Each selection type operates independently.
+    struct SelectionState {
+        di::Vector<byte> data;
+    };
+
+public:
+    constexpr static auto request_timeout = di::chrono::Seconds(1);
+
+    struct Identifier {
+        u64 session_id { 0 };
+        u64 tab_id { 0 };
+        u64 pane_id { 0 };
+    };
+
+    struct Reply {
+        Identifier identifier;
+        terminal::SelectionType type = terminal::SelectionType::Selection;
+        di::Vector<byte> data;
+    };
+
+    explicit Clipboard(Feature features);
+
+    auto set_clipboard(terminal::SelectionType type, di::Vector<byte> data,
+                       dius::SteadyClock::TimePoint reception = dius::SteadyClock::now()) -> bool;
+    auto request_clipboard(terminal::SelectionType type, Identifier const& identifier,
+                           dius::SteadyClock::TimePoint reception = dius::SteadyClock::now()) -> bool;
+    void got_clipboard_response(terminal::SelectionType type, di::Vector<byte> data,
+                                dius::SteadyClock::TimePoint reception = dius::SteadyClock::now());
+    auto get_replies(dius::SteadyClock::TimePoint reception = dius::SteadyClock::now()) -> di::Vector<Reply>;
+
+private:
+    void expire(dius::SteadyClock::TimePoint reception);
+
+    Feature m_features { Feature::None };
+    di::Array<SelectionState, usize(terminal::SelectionType::Max)> m_state;
+    di::Vector<Reply> m_replies;
+};
+}

--- a/lib/include/ttx/clipboard.h
+++ b/lib/include/ttx/clipboard.h
@@ -1,10 +1,29 @@
 #pragma once
 
+#include "di/reflect/prelude.h"
 #include "dius/steady_clock.h"
 #include "ttx/features.h"
 #include "ttx/terminal/escapes/osc_52.h"
 
 namespace ttx {
+/// @brief Clipboard modes
+enum class ClipboardMode {
+    System,               ///< Attempt to read and write the system clipboard
+    SystemWriteLocalRead, ///< Write to system clipboard but read from internal clipboard
+    SystemWriteNoRead,    ///< Write to system clipboard but disallow reading clipboard
+    Local,                ///< Read and write to internal clipboard
+    LocalWriteNoRead,     ///< Write to internal clipboard but disallow reading clipboard
+    Disabled,             ///< Disallow read/writing the clipboard
+};
+
+constexpr auto tag_invoke(di::Tag<di::reflect>, di::InPlaceType<ClipboardMode>) {
+    using enum ClipboardMode;
+    return di::make_enumerators<"ClipboardMode">(
+        di::enumerator<"System", System>, di::enumerator<"SystemWriteLocalRead", SystemWriteLocalRead>,
+        di::enumerator<"SystemWriteNoRead", SystemWriteNoRead>, di::enumerator<"Local", Local>,
+        di::enumerator<"LocalWriteNoRead", LocalWriteNoRead>, di::enumerator<"Disabled", Disabled>);
+}
+
 /// @brief Implementation of clipboard handling for ttx
 ///
 /// This class supports a number of different simulataneous
@@ -30,7 +49,7 @@ public:
         di::Vector<byte> data;
     };
 
-    explicit Clipboard(Feature features);
+    explicit Clipboard(ClipboardMode mode, Feature features);
 
     auto set_clipboard(terminal::SelectionType type, di::Vector<byte> data,
                        dius::SteadyClock::TimePoint reception = dius::SteadyClock::now()) -> bool;
@@ -43,6 +62,7 @@ public:
 private:
     void expire(dius::SteadyClock::TimePoint reception);
 
+    ClipboardMode m_mode { ClipboardMode::System };
     Feature m_features { Feature::None };
     di::Array<SelectionState, usize(terminal::SelectionType::Max)> m_state;
     di::Vector<Reply> m_replies;

--- a/lib/include/ttx/escape_sequence_parser.h
+++ b/lib/include/ttx/escape_sequence_parser.h
@@ -5,6 +5,7 @@
 #include "di/function/container/function.h"
 #include "di/reflect/prelude.h"
 #include "di/vocab/variant/prelude.h"
+#include "ttx/features.h"
 #include "ttx/params.h"
 
 namespace ttx {
@@ -99,7 +100,8 @@ public:
     };
 
     auto parse_application_escape_sequences(di::StringView data) -> di::Span<ParserResult>;
-    auto parse_input_escape_sequences(di::StringView data, bool flush = true) -> di::Span<ParserResult>;
+    auto parse_input_escape_sequences(di::StringView data, Feature features = Feature::None, bool flush = true)
+        -> di::Span<ParserResult>;
 
 private:
 // VT500-Series parser states from https://vt100.net/emu/dec_ansi_parser

--- a/lib/include/ttx/escape_sequence_parser.h
+++ b/lib/include/ttx/escape_sequence_parser.h
@@ -117,6 +117,7 @@ private:
     M(CsiParam, csi_param)                     \
     M(CsiIntermediate, csi_intermediate)       \
     M(CsiIgnore, csi_ignore)                   \
+    M(Ss3, ss3)                                \
     M(DcsEntry, dcs_entry)                     \
     M(DcsParam, dcs_param)                     \
     M(DcsIntermediate, dcs_intermediate)       \
@@ -124,8 +125,7 @@ private:
     M(DcsIgnore, dcs_ignore)                   \
     M(OscString, osc_string)                   \
     M(ApcString, apc_string)                   \
-    M(SosPmString, sos_pm_string)              \
-    M(Ss3, ss3)
+    M(SosPmString, sos_pm_string)
 
     enum class State {
 #define __ENUMERATE_STATE(N, n) N,
@@ -172,6 +172,7 @@ private:
     Params m_params;
     bool m_last_separator_was_colon { false };
     bool m_saw_legacy_string_terminator { false };
+    c32 m_prev {};
     Mode m_mode { Mode::Application };
     di::Vector<ParserResult> m_result;
 };

--- a/lib/include/ttx/pane.h
+++ b/lib/include/ttx/pane.h
@@ -19,6 +19,7 @@
 #include "ttx/renderer.h"
 #include "ttx/size.h"
 #include "ttx/terminal.h"
+#include "ttx/terminal/escapes/osc_52.h"
 #include "ttx/terminal/escapes/osc_7.h"
 
 namespace ttx {
@@ -31,8 +32,8 @@ struct PaneHooks {
     /// @brief controlled callback when the terminal buffer has updated.
     di::Function<void(Pane&)> did_update;
 
-    /// @brief Application controlled callback when text is selected.
-    di::Function<void(di::Span<byte const>, bool)> did_selection;
+    /// @brief Application controlled callback when a clipboard set/request is invoked.
+    di::Function<void(terminal::OSC52, bool)> did_selection;
 
     /// @brief Application controlled callback when APC command is set.
     di::Function<void(di::StringView)> apc_passthrough;
@@ -111,6 +112,7 @@ public:
     void resize(Size const& size);
     void scroll(Direction direction, i32 amount_in_cells);
     auto save_state(di::PathView path) -> di::Result<>;
+    void send_clipboard(terminal::SelectionType selection_type, di::Vector<byte> data);
     void stop_capture();
     void soft_reset();
     void exit();

--- a/lib/include/ttx/terminal.h
+++ b/lib/include/ttx/terminal.h
@@ -11,6 +11,7 @@
 #include "ttx/params.h"
 #include "ttx/paste_event_io.h"
 #include "ttx/size.h"
+#include "ttx/terminal/escapes/osc_52.h"
 #include "ttx/terminal/escapes/osc_7.h"
 #include "ttx/terminal/screen.h"
 
@@ -19,7 +20,7 @@ struct SetClipboard {
     di::Vector<byte> data;
 };
 
-using TerminalEvent = di::Variant<SetClipboard, APC, terminal::OSC7>;
+using TerminalEvent = di::Variant<APC, terminal::OSC7, terminal::OSC52>;
 
 class Terminal {
     struct ScreenState {

--- a/lib/include/ttx/terminal/escapes/osc_52.h
+++ b/lib/include/ttx/terminal/escapes/osc_52.h
@@ -16,6 +16,8 @@ enum class SelectionType : u8 {
     _5,
     _6,
     _7,
+
+    Max,
 };
 
 constexpr auto tag_invoke(di::Tag<di::reflect>, di::InPlaceType<SelectionType>) {
@@ -47,7 +49,7 @@ constexpr auto tag_invoke(di::Tag<di::reflect>, di::InPlaceType<SelectionType>) 
 /// OSC 52 is specified
 /// [here](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h4-Operating-System-Commands:OSC-Ps;Pt-ST:Ps-=-5-2.101B).
 struct OSC52 {
-    di::StaticVector<SelectionType, di::Constexpr<10zu>> selections {};
+    di::StaticVector<SelectionType, di::Constexpr<usize(SelectionType::Max)>> selections {};
     di::Base64<> data;
     bool query { false };
 

--- a/lib/include/ttx/terminal/escapes/osc_52.h
+++ b/lib/include/ttx/terminal/escapes/osc_52.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "di/reflect/prelude.h"
+#include "di/serialization/base64.h"
+
+namespace ttx::terminal {
+/// @brief Represents the type of selection being modifed by an OSC 52 sequence
+enum class SelectionType : u8 {
+    Clipboard, ///< Standard user clipboard (default)
+    Selection, ///< Primary selection clipboard
+    _0,        ///< Numbered buffers, never forwarded to the outer terminal
+    _1,
+    _2,
+    _3,
+    _4,
+    _5,
+    _6,
+    _7,
+};
+
+constexpr auto tag_invoke(di::Tag<di::reflect>, di::InPlaceType<SelectionType>) {
+    using enum SelectionType;
+    return di::make_enumerators<"SelectionType">(
+        di::enumerator<"Clipboard", Clipboard>, di::enumerator<"Selection", Selection>, di::enumerator<"0", _0>,
+        di::enumerator<"1", _1>, di::enumerator<"2", _2>, di::enumerator<"3", _3>, di::enumerator<"4", _4>,
+        di::enumerator<"5", _5>, di::enumerator<"6", _6>, di::enumerator<"7", _7>);
+}
+
+/// @brief Represents an OSC 52 sequence, which allows for modifying or querying the clipboard
+///
+/// Although xterm originally specified 10 different selection types (c,p,q,s,0-7), modern terminals
+/// only support 'c' and 'p' (clipboard and primary selection), with 's' being mapped directly to 'p'.
+/// 'c' is the primary clipboard users expect to interact with, and is the default. Note this differs
+/// from xterm which says the default clipboard is "s 0".
+///
+/// Some terminals will ignore requests to the other selection types (kitty), while others map all other
+/// types to 'c' (ghostty). Some terminals also only implementing writing the clipboard, not reading
+/// (wezterm). Additionally terminals may have a user-provided setting to opt-out of clipboard functionality.
+/// In this case, the terminal should always return an empty selection but we have handle our requests getting
+/// ignored.
+///
+/// Therefore, when parsing OSC 52 messages, we must map the selection types appropriately instead of just
+/// passing them through. Also, we will reserve the numbered buffers for selections which are local to the
+/// ttx instance (handled fully internally). This will prove useful later, and is easy implement, because
+/// we need to have a internal clipboard anyway to handle terminals which don't support OSC 52 at all.
+///
+/// OSC 52 is specified
+/// [here](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h4-Operating-System-Commands:OSC-Ps;Pt-ST:Ps-=-5-2.101B).
+struct OSC52 {
+    di::StaticVector<SelectionType, di::Constexpr<10zu>> selections {};
+    di::Base64<> data;
+    bool query { false };
+
+    static auto parse(di::StringView data) -> di::Optional<OSC52>;
+
+    auto serialize() const -> di::String;
+
+    auto operator==(OSC52 const& other) const -> bool = default;
+
+    constexpr friend auto tag_invoke(di::Tag<di::reflect>, di::InPlaceType<OSC52>) {
+        return di::make_fields<"OSC52">(di::field<"selections", &OSC52::selections>, di::field<"data", &OSC52::data>,
+                                        di::field<"query", &OSC52::query>);
+    }
+};
+}

--- a/lib/include/ttx/terminal_input.h
+++ b/lib/include/ttx/terminal_input.h
@@ -4,6 +4,7 @@
 #include "di/container/vector/vector.h"
 #include "di/vocab/variant/variant.h"
 #include "ttx/escape_sequence_parser.h"
+#include "ttx/features.h"
 #include "ttx/focus_event.h"
 #include "ttx/key_event.h"
 #include "ttx/mouse_event.h"
@@ -11,16 +12,17 @@
 #include "ttx/terminal/escapes/device_attributes.h"
 #include "ttx/terminal/escapes/device_status.h"
 #include "ttx/terminal/escapes/mode.h"
+#include "ttx/terminal/escapes/osc_52.h"
 #include "ttx/terminal/escapes/terminfo_string.h"
 
 namespace ttx {
 using Event = di::Variant<KeyEvent, MouseEvent, FocusEvent, PasteEvent, terminal::PrimaryDeviceAttributes,
                           terminal::ModeQueryReply, terminal::CursorPositionReport, terminal::KittyKeyReport,
-                          terminal::StatusStringResponse, terminal::TerminfoString>;
+                          terminal::StatusStringResponse, terminal::TerminfoString, terminal::OSC52>;
 
 class TerminalInputParser {
 public:
-    auto parse(di::StringView input) -> di::Vector<Event>;
+    auto parse(di::StringView input, Feature features) -> di::Vector<Event>;
 
 private:
     void handle(PrintableCharacter const& printable_character);

--- a/lib/src/clipboard.cpp
+++ b/lib/src/clipboard.cpp
@@ -1,0 +1,38 @@
+#include "ttx/clipboard.h"
+
+#include "di/assert/prelude.h"
+#include "ttx/features.h"
+
+namespace ttx {
+Clipboard::Clipboard(Feature features) : m_features(features) {}
+
+auto Clipboard::set_clipboard(terminal::SelectionType type, di::Vector<byte> data,
+                              dius::SteadyClock::TimePoint reception) -> bool {
+    ASSERT_LT(type, terminal::SelectionType::Max);
+    m_state[usize(type)].data = di::move(data);
+    return true;
+}
+
+auto Clipboard::request_clipboard(terminal::SelectionType type, Identifier const& identifier,
+                                  dius::SteadyClock::TimePoint reception) -> bool {
+    ASSERT_LT(type, terminal::SelectionType::Max);
+    m_replies.push_back(Reply {
+        .identifier = identifier,
+        .type = type,
+        .data = m_state[usize(type)].data.clone(),
+    });
+    return true;
+}
+
+void Clipboard::got_clipboard_response(terminal::SelectionType type, di::Vector<byte> data,
+                                       dius::SteadyClock::TimePoint reception) {
+    ASSERT_LT(type, terminal::SelectionType::Max);
+}
+
+auto Clipboard::get_replies(dius::SteadyClock::TimePoint reception) -> di::Vector<Reply> {
+    expire(reception);
+    return di::exchange(m_replies, di::Vector<Reply> {});
+}
+
+void Clipboard::expire(dius::SteadyClock::TimePoint reception) {}
+}

--- a/lib/src/clipboard.cpp
+++ b/lib/src/clipboard.cpp
@@ -2,6 +2,7 @@
 
 #include "di/assert/prelude.h"
 #include "ttx/features.h"
+#include "ttx/terminal/escapes/osc_52.h"
 
 namespace ttx {
 Clipboard::Clipboard(ClipboardMode mode, Feature features) : m_mode(mode), m_features(features) {}
@@ -9,24 +10,91 @@ Clipboard::Clipboard(ClipboardMode mode, Feature features) : m_mode(mode), m_fea
 auto Clipboard::set_clipboard(terminal::SelectionType type, di::Vector<byte> data,
                               dius::SteadyClock::TimePoint reception) -> bool {
     ASSERT_LT(type, terminal::SelectionType::Max);
-    m_state[usize(type)].data = di::move(data);
-    return true;
+
+    auto _ = di::ScopeExit([&] {
+        expire(reception);
+    });
+
+    auto write_system = false;
+    auto action = action_for_clipboard_write(type);
+    switch (action) {
+        case ClipboardWriteAction::Ignore:
+            break;
+        case ClipboardWriteAction::WriteSystem:
+            write_system = true;
+            [[fallthrough]];
+        case ClipboardWriteAction::WriteLocal:
+            m_state[usize(type)].data = di::move(data);
+            break;
+    }
+    return write_system;
 }
 
 auto Clipboard::request_clipboard(terminal::SelectionType type, Identifier const& identifier,
                                   dius::SteadyClock::TimePoint reception) -> bool {
     ASSERT_LT(type, terminal::SelectionType::Max);
-    m_replies.push_back(Reply {
-        .identifier = identifier,
-        .type = type,
-        .data = m_state[usize(type)].data.clone(),
-    });
-    return true;
+
+    expire(reception);
+
+    auto request_system = false;
+    auto data = di::Optional<di::Vector<byte>> {};
+    auto action = action_for_clipboard_read(type);
+    switch (action) {
+        case ClipboardReadAction::Ignore:
+            data.emplace();
+            break;
+        case ClipboardReadAction::RequestSystemReadLocal:
+            request_system = true;
+            [[fallthrough]];
+        case ClipboardReadAction::ReadLocal:
+            data = m_state[usize(type)].data.clone();
+            break;
+        case ClipboardReadAction::ReadSystem:
+            request_system = true;
+            break;
+    }
+
+    if (data) {
+        m_replies.push_back(Reply {
+            .identifier = identifier,
+            .type = type,
+            .data = di::move(data).value(),
+        });
+    } else {
+        m_state[usize(type)].requests.push(Request {
+            .reception = reception,
+            .identifier = identifier,
+        });
+    }
+    return request_system;
 }
 
 void Clipboard::got_clipboard_response(terminal::SelectionType type, di::Vector<byte> data,
                                        dius::SteadyClock::TimePoint reception) {
     ASSERT_LT(type, terminal::SelectionType::Max);
+
+    auto _ = di::ScopeExit([&] {
+        expire(reception);
+    });
+
+    auto& state = m_state[usize(type)];
+    state.system_working = true;
+
+    // Don't overwrite the clipboard if an empty response is detected. In this case, its
+    // possible the user has configured their terminal in such a way that applications don't
+    // have permission to read the clipboard. We want to fallback to our own local clipboard
+    // in this case.
+    if (!data.empty()) {
+        state.data = di::move(data);
+    }
+
+    if (auto request = state.requests.pop()) {
+        m_replies.push_back(Reply {
+            .identifier = request.value().identifier,
+            .type = type,
+            .data = state.data.clone(),
+        });
+    }
 }
 
 auto Clipboard::get_replies(dius::SteadyClock::TimePoint reception) -> di::Vector<Reply> {
@@ -34,5 +102,73 @@ auto Clipboard::get_replies(dius::SteadyClock::TimePoint reception) -> di::Vecto
     return di::exchange(m_replies, di::Vector<Reply> {});
 }
 
-void Clipboard::expire(dius::SteadyClock::TimePoint reception) {}
+void Clipboard::expire(dius::SteadyClock::TimePoint reception) {
+    for (auto [i, state] : m_state | di::enumerate) {
+        while (!state.requests.empty()) {
+            auto const& top = state.requests.top().value();
+            if (top.reception + request_timeout <= reception) {
+                m_replies.push_back(Reply {
+                    .identifier = top.identifier,
+                    .type = terminal::SelectionType(i),
+                    .data = state.data.clone(),
+                });
+                state.requests.pop();
+                state.system_working = false;
+                continue;
+            }
+            break;
+        }
+    }
+}
+
+auto Clipboard::action_for_clipboard_read(terminal::SelectionType type) -> ClipboardReadAction {
+    switch (m_mode) {
+        case ClipboardMode::System:
+            break;
+        case ClipboardMode::SystemWriteLocalRead:
+        case ClipboardMode::Local:
+            return ClipboardReadAction::ReadLocal;
+        case ClipboardMode::SystemWriteNoRead:
+        case ClipboardMode::LocalWriteNoRead:
+        case ClipboardMode::Disabled:
+            return ClipboardReadAction::Ignore;
+    }
+
+    if (!(m_features & Feature::Clipboard)) {
+        return ClipboardReadAction::ReadLocal;
+    }
+
+    if (type != terminal::SelectionType::Selection && type != terminal::SelectionType::Clipboard) {
+        return ClipboardReadAction::ReadLocal;
+    }
+
+    auto const& state = m_state[usize(type)];
+    if (state.system_working) {
+        return ClipboardReadAction::ReadSystem;
+    }
+    return ClipboardReadAction::RequestSystemReadLocal;
+}
+
+auto Clipboard::action_for_clipboard_write(terminal::SelectionType type) -> ClipboardWriteAction {
+    switch (m_mode) {
+        case ClipboardMode::System:
+        case ClipboardMode::SystemWriteLocalRead:
+        case ClipboardMode::SystemWriteNoRead:
+            break;
+        case ClipboardMode::Local:
+        case ClipboardMode::LocalWriteNoRead:
+            return ClipboardWriteAction::WriteLocal;
+        case ClipboardMode::Disabled:
+            return ClipboardWriteAction::Ignore;
+    }
+
+    if (!(m_features & Feature::Clipboard)) {
+        return ClipboardWriteAction::WriteLocal;
+    }
+
+    if (type != terminal::SelectionType::Selection && type != terminal::SelectionType::Clipboard) {
+        return ClipboardWriteAction::WriteLocal;
+    }
+    return ClipboardWriteAction::WriteSystem;
+}
 }

--- a/lib/src/clipboard.cpp
+++ b/lib/src/clipboard.cpp
@@ -4,7 +4,7 @@
 #include "ttx/features.h"
 
 namespace ttx {
-Clipboard::Clipboard(Feature features) : m_features(features) {}
+Clipboard::Clipboard(ClipboardMode mode, Feature features) : m_mode(mode), m_features(features) {}
 
 auto Clipboard::set_clipboard(terminal::SelectionType type, di::Vector<byte> data,
                               dius::SteadyClock::TimePoint reception) -> bool {

--- a/lib/src/feature.cpp
+++ b/lib/src/feature.cpp
@@ -8,6 +8,7 @@
 #include "ttx/terminal/escapes/device_attributes.h"
 #include "ttx/terminal/escapes/device_status.h"
 #include "ttx/terminal/escapes/mode.h"
+#include "ttx/terminal/escapes/osc_52.h"
 #include "ttx/terminal/escapes/osc_66.h"
 #include "ttx/terminal/escapes/terminfo_string.h"
 #include "ttx/terminal_input.h"
@@ -118,6 +119,8 @@ public:
             }
         }
     }
+
+    void handle_event(terminal::OSC52 const&) {}
 
 private:
     Feature m_result = Feature::None;
@@ -232,7 +235,7 @@ auto detect_features(dius::SyncFile& terminal) -> di::Result<Feature> {
         auto nread = TRY(terminal.read_some(buffer.span()));
 
         auto utf8_string = utf8_decoder.decode(buffer | di::take(nread));
-        auto events = parser.parse(utf8_string);
+        auto events = parser.parse(utf8_string, Feature::None);
         for (auto const& event : events) {
             di::visit(
                 [&](auto const& ev) {

--- a/lib/src/terminal.cpp
+++ b/lib/src/terminal.cpp
@@ -1247,8 +1247,12 @@ void Terminal::set_use_alternate_screen_buffer(bool b) {
     if (b) {
         m_alternate_screen = di::make_box<ScreenState>(size(), terminal::Screen::ScrollBackEnabled::No);
     } else {
+        auto new_size = size();
+
         ASSERT(m_alternate_screen);
         m_alternate_screen = {};
+
+        active_screen().screen.resize(new_size);
     }
     invalidate_all();
 }

--- a/lib/src/terminal/escapes/osc_52.cpp
+++ b/lib/src/terminal/escapes/osc_52.cpp
@@ -1,0 +1,73 @@
+#include "ttx/terminal/escapes/osc_52.h"
+
+#include "di/format/prelude.h"
+
+namespace ttx::terminal {
+constexpr auto selection_mapping = di::Array {
+    di::Tuple { SelectionType::Clipboard, U'c' }, di::Tuple { SelectionType::Selection, U'p' },
+    di::Tuple { SelectionType::Selection, U's' }, di::Tuple { SelectionType::_0, U'0' },
+    di::Tuple { SelectionType::_1, U'1' },        di::Tuple { SelectionType::_2, U'2' },
+    di::Tuple { SelectionType::_3, U'3' },        di::Tuple { SelectionType::_4, U'4' },
+    di::Tuple { SelectionType::_5, U'5' },        di::Tuple { SelectionType::_6, U'6' },
+    di::Tuple { SelectionType::_7, U'7' },
+};
+
+auto OSC52::parse(di::StringView data) -> di::Optional<OSC52> {
+    auto semicolon = data.find(U';');
+    if (!semicolon) {
+        return {};
+    }
+
+    auto result = OSC52 {};
+    auto selection = data.substr(data.begin(), semicolon.begin());
+    auto added = u16(0);
+    for (auto ch : selection) {
+        for (auto [t, c] : selection_mapping) {
+            if (c == ch) {
+                if (!(added & (1 << u16(t)))) {
+                    (void) result.selections.push_back(t);
+                    added |= (1 << u16(t));
+                    break;
+                }
+            }
+        }
+    }
+    if (result.selections.empty()) {
+        if (!selection.empty()) {
+            return {};
+        }
+        (void) result.selections.push_back(SelectionType::Clipboard);
+    }
+
+    data = data.substr(semicolon.end());
+    if (data == "?"_sv) {
+        result.query = true;
+        return result;
+    }
+
+    // Xterm spec says that invalid base64 strings will result in clearing
+    // the selection, instead of ignoring. Which is weird, but we'll do what
+    // it says.
+    result.data = di::parse<di::Base64<>>(data).value_or(di::Base64<>());
+    return result;
+}
+
+auto OSC52::serialize() const -> di::String {
+    auto selection = "c"_s;
+    if (!selections.empty()) {
+        selection = selections | di::transform([](SelectionType type) -> c32 {
+                        for (auto [t, c] : selection_mapping) {
+                            if (t == type) {
+                                return c;
+                            }
+                        }
+                        return 'c';
+                    }) |
+                    di::to<di::String>();
+    }
+    if (query) {
+        return *di::present("\033]52;{};?\033\\"_sv, selection);
+    }
+    return *di::present("\033]52;{};{}\033\\"_sv, selection, data);
+}
+}

--- a/lib/src/terminal/screen.cpp
+++ b/lib/src/terminal/screen.cpp
@@ -1354,10 +1354,11 @@ void Screen::begin_selection(SelectionPoint const& point, BeginSelectionMode mod
             // as part of a word. This algorithm should work well enough
             // while still being simple to implement.
             auto text_per_cell = di::Vector<di::Tuple<di::StringView, bool>> {};
-            for (auto row : iterate_row(adjusted_point.row)) {
+            for (auto row : row_group.iterate_row(row_index)) {
                 auto [_, cell, text, _, _, _] = row;
                 text_per_cell.push_back({ text, cell.is_nonprimary_in_multi_cell() });
             }
+            ASSERT_EQ(text_per_cell.size(), row.cells.size());
             auto start = adjusted_point.col;
             auto end = adjusted_point.col;
             while (start > 0) {
@@ -1369,7 +1370,7 @@ void Screen::begin_selection(SelectionPoint const& point, BeginSelectionMode mod
                 }
                 start--;
             }
-            while (end < max_col_inclusive()) {
+            while (end < row.cells.size() - 1) {
                 auto [text, is_nonprimary_in_multi_cell] = text_per_cell[end + 1];
                 if (!is_nonprimary_in_multi_cell &&
                     (text.empty() || dius::unicode::general_category(*text.front()) ==

--- a/lib/src/terminal_input.cpp
+++ b/lib/src/terminal_input.cpp
@@ -60,8 +60,10 @@ void TerminalInputParser::handle(DCS const& dcs) {
 }
 
 void TerminalInputParser::handle(OSC const& osc) {
-    if (auto osc52 = terminal::OSC52::parse(osc.data)) {
-        m_events.emplace_back(di::move(osc52).value());
+    if (osc.data.starts_with("52;"_sv)) {
+        if (auto osc52 = terminal::OSC52::parse(osc.data.substr(di::next(osc.data.begin(), 3)))) {
+            m_events.emplace_back(di::move(osc52).value());
+        }
     }
 }
 

--- a/lib/test/src/test_clipboard.cpp
+++ b/lib/test/src/test_clipboard.cpp
@@ -1,0 +1,73 @@
+#include "di/test/prelude.h"
+#include "ttx/clipboard.h"
+#include "ttx/features.h"
+#include "ttx/terminal/escapes/osc_52.h"
+
+namespace clipboard {
+static void system() {
+    auto clipboard = ttx::Clipboard(ttx::ClipboardMode::System, ttx::Feature::Clipboard);
+
+    auto t = dius::SteadyClock::TimePoint(di::chrono::Seconds(1000));
+    clipboard.got_clipboard_response(ttx::terminal::SelectionType::Clipboard, { '1'_b }, t);
+    ASSERT(clipboard.request_clipboard(ttx::terminal::SelectionType::Clipboard, { 1, 2, 3 }, t));
+    ASSERT(clipboard.get_replies(t).empty());
+
+    clipboard.got_clipboard_response(ttx::terminal::SelectionType::Clipboard, { '4'_b }, t);
+    auto responses = clipboard.get_replies(t);
+    ASSERT_EQ(responses.size(), 1zu);
+    ASSERT_EQ(responses[0].identifier, ttx::Clipboard::Identifier(1, 2, 3));
+    ASSERT_EQ(responses[0].type, ttx::terminal::SelectionType::Clipboard);
+    ASSERT_EQ(responses[0].data, di::Vector { '4'_b });
+
+    // Expiration
+    ASSERT(clipboard.request_clipboard(ttx::terminal::SelectionType::Clipboard, { 1, 2, 3 }, t));
+    ASSERT(clipboard.get_replies(t).empty());
+    t += ttx::Clipboard::request_timeout;
+    responses = clipboard.get_replies(t);
+    ASSERT_EQ(responses.size(), 1zu);
+    ASSERT_EQ(responses[0].identifier, ttx::Clipboard::Identifier(1, 2, 3));
+    ASSERT_EQ(responses[0].type, ttx::terminal::SelectionType::Clipboard);
+    ASSERT_EQ(responses[0].data, di::Vector { '4'_b });
+
+    // Now, the request will be filled immiedately, since the system clipboard considered broken.
+    ASSERT(clipboard.request_clipboard(ttx::terminal::SelectionType::Clipboard, { 1, 2, 3 }, t));
+    responses = clipboard.get_replies(t);
+    ASSERT_EQ(responses.size(), 1zu);
+    ASSERT_EQ(responses[0].identifier, ttx::Clipboard::Identifier(1, 2, 3));
+    ASSERT_EQ(responses[0].type, ttx::terminal::SelectionType::Clipboard);
+    ASSERT_EQ(responses[0].data, di::Vector { '4'_b });
+
+    // Setting the clipboard works
+    ASSERT(clipboard.set_clipboard(ttx::terminal::SelectionType::Clipboard, { '5'_b }, t));
+    ASSERT(clipboard.request_clipboard(ttx::terminal::SelectionType::Clipboard, { 1, 2, 3 }, t));
+    responses = clipboard.get_replies(t);
+    ASSERT_EQ(responses.size(), 1zu);
+    ASSERT_EQ(responses[0].identifier, ttx::Clipboard::Identifier(1, 2, 3));
+    ASSERT_EQ(responses[0].type, ttx::terminal::SelectionType::Clipboard);
+    ASSERT_EQ(responses[0].data, di::Vector { '5'_b });
+}
+
+static void local() {
+    auto clipboard = ttx::Clipboard(ttx::ClipboardMode::Local, ttx::Feature::Clipboard);
+
+    auto t = dius::SteadyClock::TimePoint(di::chrono::Seconds(1000));
+    ASSERT(!clipboard.request_clipboard(ttx::terminal::SelectionType::Clipboard, { 1, 2, 3 }, t));
+    auto responses = clipboard.get_replies(t);
+    ASSERT_EQ(responses.size(), 1zu);
+    ASSERT_EQ(responses[0].identifier, ttx::Clipboard::Identifier(1, 2, 3));
+    ASSERT_EQ(responses[0].type, ttx::terminal::SelectionType::Clipboard);
+    ASSERT_EQ(responses[0].data, di::Vector<byte> {});
+
+    // Setting the clipboard works
+    ASSERT(!clipboard.set_clipboard(ttx::terminal::SelectionType::Clipboard, { '5'_b }, t));
+    ASSERT(!clipboard.request_clipboard(ttx::terminal::SelectionType::Clipboard, { 1, 2, 3 }, t));
+    responses = clipboard.get_replies(t);
+    ASSERT_EQ(responses.size(), 1zu);
+    ASSERT_EQ(responses[0].identifier, ttx::Clipboard::Identifier(1, 2, 3));
+    ASSERT_EQ(responses[0].type, ttx::terminal::SelectionType::Clipboard);
+    ASSERT_EQ(responses[0].data, di::Vector { '5'_b });
+}
+
+TEST(clipboard, system)
+TEST(clipboard, local)
+}

--- a/lib/test/src/test_escape_sequence_parser.cpp
+++ b/lib/test/src/test_escape_sequence_parser.cpp
@@ -86,7 +86,7 @@ static void apc() {
 static void input() {
     using namespace ttx;
 
-    constexpr auto input = "\033A\033OA\033\x00\033\033\033[AA\x18\x1a\033\x1a\033]"_sv;
+    constexpr auto input = "\033A\033OA\033\x00\033\033\033[AA\x18\x1a\033\x1a\033]8;asdf\033\\\033]"_sv;
 
     auto expected = di::Array {
         ParserResult { ControlCharacter(U'A', true) },
@@ -98,6 +98,7 @@ static void input() {
         ParserResult { ControlCharacter(U'\x18', false) },
         ParserResult { ControlCharacter(U'\x1a', false) },
         ParserResult { ControlCharacter(U'\x1a', true) },
+        ParserResult { OSC("8;asdf"_s, "\033\\"_sv) },
         ParserResult { ControlCharacter(U']', true) },
     };
 

--- a/lib/test/src/test_escape_sequence_parser.cpp
+++ b/lib/test/src/test_escape_sequence_parser.cpp
@@ -86,7 +86,7 @@ static void apc() {
 static void input() {
     using namespace ttx;
 
-    constexpr auto input = "\033A\033OA\033\x00\033\033\033[AA\033]\x18\x1a\033\x1a\033"_sv;
+    constexpr auto input = "\033A\033OA\033\x00\033\033\033[AA\x18\x1a\033\x1a\033]"_sv;
 
     auto expected = di::Array {
         ParserResult { ControlCharacter(U'A', true) },
@@ -95,11 +95,10 @@ static void input() {
         ParserResult { ControlCharacter(U'\033', true) },
         ParserResult { CSI(""_s, {}, U'A') },
         ParserResult { PrintableCharacter(U'A') },
-        ParserResult { ControlCharacter(U']', true) },
         ParserResult { ControlCharacter(U'\x18', false) },
         ParserResult { ControlCharacter(U'\x1a', false) },
         ParserResult { ControlCharacter(U'\x1a', true) },
-        ParserResult { ControlCharacter(U'\033', false) },
+        ParserResult { ControlCharacter(U']', true) },
     };
 
     auto parser = EscapeSequenceParser {};

--- a/lib/test/src/test_osc_52.cpp
+++ b/lib/test/src/test_osc_52.cpp
@@ -1,0 +1,99 @@
+#include "di/test/prelude.h"
+#include "ttx/terminal/escapes/osc_52.h"
+
+namespace osc_52 {
+using namespace ttx;
+using namespace ttx::terminal;
+
+static auto make_selections(di::SameAs<SelectionType> auto... args) {
+    auto array = di::Array { args... };
+    auto result = di::StaticVector<SelectionType, di::Constexpr<10zu>> {};
+    for (auto x : array) {
+        ASSERT(result.push_back(x));
+    }
+    return result;
+}
+
+static void test_parse() {
+    struct Case {
+        di::StringView input {};
+        di::Optional<OSC52> expected {};
+    };
+
+    auto cases = di::Array {
+        // Defaults.
+        Case {
+            ";"_sv,
+            OSC52 { make_selections(SelectionType::Clipboard), {} },
+        },
+        // Query
+        Case {
+            "p;?"_sv,
+            OSC52 { make_selections(SelectionType::Selection), {}, true },
+        },
+        // Data
+        Case {
+            "01s;abcd"_sv,
+            OSC52 { make_selections(SelectionType::_0, SelectionType::_1, SelectionType::Selection), "abcd"_base64 },
+        },
+        // Duplicate selections
+        Case {
+            "01s000000000000000000000000000000;abcd"_sv,
+            OSC52 { make_selections(SelectionType::_0, SelectionType::_1, SelectionType::Selection), "abcd"_base64 },
+        },
+        // Invalid base 64 yields empty
+        Case {
+            ";~~~~~~~~~~~~~~"_sv,
+            OSC52 { make_selections(SelectionType::Clipboard), {} },
+        },
+        // Invalid
+        Case {
+            ""_sv,
+        },
+        Case {
+            "q;"_sv,
+        },
+        Case {
+            "c"_sv,
+        },
+    };
+
+    for (auto const& [input, expected] : cases) {
+        auto result = OSC52::parse(input);
+        ASSERT_EQ(expected, result);
+    }
+}
+
+static void test_serialize() {
+    struct Case {
+        OSC52 input {};
+        di::StringView expected {};
+    };
+
+    auto cases = di::Array {
+        // Empty
+        Case {
+            {},
+            "\033]52;c;\033\\"_sv,
+        },
+        // Query
+        Case {
+            { make_selections(SelectionType::Selection), {}, true },
+            "\033]52;p;?\033\\"_sv,
+        },
+        // Data
+        Case {
+            { make_selections(SelectionType::_0, SelectionType::_1), "YWJjZAo="_base64 },
+            "\033]52;01;YWJjZAo=\033\\"_sv,
+        },
+    };
+
+    for (auto const& [input, expected] : cases) {
+        auto result = input.serialize();
+        ASSERT_EQ(expected, result);
+    }
+}
+
+TEST(osc_52, test_parse)
+TEST(osc_52, test_serialize)
+}

--- a/lib/test/src/test_terminal_input.cpp
+++ b/lib/test/src/test_terminal_input.cpp
@@ -1,4 +1,5 @@
 #include "di/test/prelude.h"
+#include "ttx/features.h"
 #include "ttx/focus_event.h"
 #include "ttx/key_event.h"
 #include "ttx/modifiers.h"
@@ -27,7 +28,7 @@ static void keyboard() {
     };
 
     auto parser = TerminalInputParser {};
-    auto actual = parser.parse(input);
+    auto actual = parser.parse(input, Feature::None);
 
     for (auto const& [ex, ac] : di::zip(expected, actual)) {
         ASSERT_EQ(ex, ac);
@@ -45,7 +46,7 @@ static void mouse() {
     };
 
     auto parser = TerminalInputParser {};
-    auto actual = parser.parse(input);
+    auto actual = parser.parse(input, Feature::None);
 
     for (auto const& [ex, ac] : di::zip(expected, actual)) {
         ASSERT_EQ(ex, ac);
@@ -64,7 +65,7 @@ static void focus() {
     };
 
     auto parser = TerminalInputParser {};
-    auto actual = parser.parse(input);
+    auto actual = parser.parse(input, Feature::None);
 
     for (auto const& [ex, ac] : di::zip(expected, actual)) {
         ASSERT_EQ(ex, ac);
@@ -86,7 +87,7 @@ static void paste() {
     };
 
     auto parser = TerminalInputParser {};
-    auto actual = parser.parse(input);
+    auto actual = parser.parse(input, Feature::None);
 
     for (auto const& [ex, ac] : di::zip(expected, actual)) {
         ASSERT_EQ(ex, ac);

--- a/meta/nix/homemodules.nix
+++ b/meta/nix/homemodules.nix
@@ -45,6 +45,21 @@
               default = null;
               description = ''Set TERM enviornment variable'';
             };
+
+            clipboard = lib.mkOption {
+              type =
+                with lib.types;
+                nullOr (enum [
+                  "System"
+                  "SystemWriteLocalRead"
+                  "SystemWriteNoRead"
+                  "Local"
+                  "LocalWriteNoRead"
+                  "Disabled"
+                ]);
+              default = null;
+              description = ''Set clipboard mode'';
+            };
           };
         };
       };
@@ -61,13 +76,18 @@
               " --term ${config.programs.ttx.settings.term}"
             else
               "";
+          clipboard =
+            if config.programs.ttx.settings.clipboard != null then
+              " --clipboard ${config.programs.ttx.settings.clipboard}"
+            else
+              "";
         in
         lib.mkIf config.programs.ttx.enable {
           home.packages =
             if config.programs.ttx.package == null then [ ] else [ config.programs.ttx.package ];
 
           home.shellAliases = {
-            ttx = "ttx --prefix ${config.programs.ttx.settings.prefix}${autolayout}${term} ${config.programs.ttx.settings.shell}";
+            ttx = "ttx --prefix ${config.programs.ttx.settings.prefix}${autolayout}${term}${clipboard} ${config.programs.ttx.settings.shell}";
           };
         };
     };

--- a/src/input.h
+++ b/src/input.h
@@ -5,6 +5,7 @@
 #include "key_bind.h"
 #include "layout_state.h"
 #include "save_layout.h"
+#include "ttx/features.h"
 #include "ttx/focus_event.h"
 #include "ttx/key_event.h"
 #include "ttx/mouse.h"
@@ -13,6 +14,7 @@
 #include "ttx/terminal/escapes/device_attributes.h"
 #include "ttx/terminal/escapes/device_status.h"
 #include "ttx/terminal/escapes/mode.h"
+#include "ttx/terminal/escapes/osc_52.h"
 #include "ttx/terminal/escapes/terminfo_string.h"
 
 namespace ttx {
@@ -21,11 +23,11 @@ class RenderThread;
 class InputThread {
 public:
     static auto create(CreatePaneArgs create_pane_args, di::Vector<KeyBind> key_binds,
-                       di::Synchronized<LayoutState>& layout_state, RenderThread& render_thread,
+                       di::Synchronized<LayoutState>& layout_state, Feature features, RenderThread& render_thread,
                        SaveLayoutThread& save_layout_thread) -> di::Result<di::Box<InputThread>>;
 
     explicit InputThread(CreatePaneArgs create_pane_args, di::Vector<KeyBind> key_binds,
-                         di::Synchronized<LayoutState>& layout_state, RenderThread& render_thread,
+                         di::Synchronized<LayoutState>& layout_state, Feature features, RenderThread& render_thread,
                          SaveLayoutThread& save_layout_thread);
     ~InputThread();
 
@@ -36,16 +38,17 @@ private:
 
     void set_input_mode(InputMode mode);
 
-    void handle_event(KeyEvent const& event);
-    void handle_event(MouseEvent const& event);
-    void handle_event(FocusEvent const& event);
-    void handle_event(PasteEvent const& event);
-    void handle_event(terminal::PrimaryDeviceAttributes const&) {}
-    void handle_event(terminal::ModeQueryReply const&) {}
-    void handle_event(terminal::CursorPositionReport const&) {}
-    void handle_event(terminal::KittyKeyReport const&) {}
-    void handle_event(terminal::StatusStringResponse const&) {}
-    void handle_event(terminal::TerminfoString const&) {}
+    void handle_event(KeyEvent&& event);
+    void handle_event(MouseEvent&& event);
+    void handle_event(FocusEvent&& event);
+    void handle_event(PasteEvent&& event);
+    void handle_event(terminal::PrimaryDeviceAttributes&&) {}
+    void handle_event(terminal::ModeQueryReply&&) {}
+    void handle_event(terminal::CursorPositionReport&&) {}
+    void handle_event(terminal::KittyKeyReport&&) {}
+    void handle_event(terminal::StatusStringResponse&&) {}
+    void handle_event(terminal::TerminfoString&&) {}
+    void handle_event(terminal::OSC52&& event);
 
     auto handle_drag(LayoutState& state, MouseCoordinate const& coordinate) -> bool;
 
@@ -57,6 +60,7 @@ private:
     di::Synchronized<LayoutState>& m_layout_state;
     RenderThread& m_render_thread;
     SaveLayoutThread& m_save_layout_thread;
+    Feature m_features { Feature::None };
     dius::Thread m_thread;
 };
 }

--- a/src/layout_state.cpp
+++ b/src/layout_state.cpp
@@ -133,6 +133,14 @@ auto LayoutState::add_session(CreatePaneArgs args, RenderThread& render_thread) 
     return add_tab(*session, di::move(args), render_thread);
 }
 
+auto LayoutState::pane_by_id(u64 session_id, u64 tab_id, u64 pane_id) -> di::Optional<Pane&> {
+    auto* session = di::find(m_sessions, session_id, &Session::id);
+    if (session == m_sessions.end()) {
+        return {};
+    }
+    return (*session)->pane_by_id(tab_id, pane_id);
+}
+
 auto LayoutState::active_session() const -> di::Optional<Session&> {
     if (!m_active_session) {
         return {};

--- a/src/layout_state.h
+++ b/src/layout_state.h
@@ -17,6 +17,7 @@ public:
     auto set_active_tab(Session& session, Tab* tab) -> bool;
     void remove_tab(Session& session, Tab& tab);
     auto remove_pane(Session& session, Tab& tab, Pane* pane) -> di::Box<Pane>;
+    auto pane_by_id(u64 session_id, u64 tab_id, u64 pane_id) -> di::Optional<Pane&>;
 
     auto add_pane(Session& session, Tab& tab, CreatePaneArgs args, Direction direction, RenderThread& render_thread)
         -> di::Result<>;

--- a/src/render.h
+++ b/src/render.h
@@ -5,9 +5,11 @@
 #include "input_mode.h"
 #include "layout_state.h"
 #include "tab.h"
+#include "ttx/clipboard.h"
 #include "ttx/features.h"
 #include "ttx/pane.h"
 #include "ttx/renderer.h"
+#include "ttx/terminal/escapes/osc_52.h"
 
 namespace ttx {
 struct PaneExited {
@@ -33,7 +35,15 @@ struct StatusMessage {
     dius::SteadyClock::Duration duration {};
 };
 
-using RenderEvent = di::Variant<Size, PaneExited, InputStatus, WriteString, StatusMessage, DoRender, MouseEvent, Exit>;
+struct ClipboardRequest {
+    terminal::OSC52 osc52;
+    di::Optional<Clipboard::Identifier> identifier;
+    bool manual { false };
+    bool reply { false };
+};
+
+using RenderEvent = di::Variant<Size, PaneExited, InputStatus, WriteString, StatusMessage, DoRender, MouseEvent,
+                                ClipboardRequest, Exit>;
 
 class RenderThread {
 public:
@@ -73,6 +83,7 @@ private:
     dius::ConditionVariable m_condition;
     di::Synchronized<LayoutState>& m_layout_state;
     di::Function<void()> m_did_exit;
+    Clipboard m_clipboard;
     Feature m_features { Feature::None };
     dius::Thread m_thread;
 };

--- a/src/render.h
+++ b/src/render.h
@@ -47,11 +47,12 @@ using RenderEvent = di::Variant<Size, PaneExited, InputStatus, WriteString, Stat
 
 class RenderThread {
 public:
-    explicit RenderThread(di::Synchronized<LayoutState>& layout_state, di::Function<void()> did_exit, Feature features);
+    explicit RenderThread(di::Synchronized<LayoutState>& layout_state, di::Function<void()> did_exit,
+                          ClipboardMode clipboard_mode, Feature features);
     ~RenderThread();
 
-    static auto create(di::Synchronized<LayoutState>& layout_state, di::Function<void()> did_exit, Feature features)
-        -> di::Result<di::Box<RenderThread>>;
+    static auto create(di::Synchronized<LayoutState>& layout_state, di::Function<void()> did_exit,
+                       ClipboardMode clipboard_mode, Feature features) -> di::Result<di::Box<RenderThread>>;
     static auto create_mock(di::Synchronized<LayoutState>& layout_state) -> RenderThread;
 
     void push_event(RenderEvent event);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -75,6 +75,14 @@ auto Session::remove_pane(Tab& tab, Pane* pane) -> di::Box<Pane> {
     return result;
 }
 
+auto Session::pane_by_id(u64 tab_id, u64 pane_id) -> di::Optional<Pane&> {
+    auto* tab = di::find(m_tabs, tab_id, &Tab::id);
+    if (tab == m_tabs.end()) {
+        return {};
+    }
+    return (*tab)->pane_by_id(pane_id);
+}
+
 auto Session::add_pane(Tab& tab, u64 pane_id, CreatePaneArgs args, Direction direction, RenderThread& render_thread)
     -> di::Result<> {
     return tab.add_pane(pane_id, m_size, di::move(args), direction, render_thread);

--- a/src/session.h
+++ b/src/session.h
@@ -21,6 +21,7 @@ public:
     auto set_active_tab(Tab* tab) -> bool;
     void remove_tab(Tab& tab);
     auto remove_pane(Tab& tab, Pane* pane) -> di::Box<Pane>;
+    auto pane_by_id(u64 tab_id, u64 pane_id) -> di::Optional<Pane&>;
 
     auto max_tab_id() const -> u64;
     auto max_pane_id() const -> u64;

--- a/src/tab.h
+++ b/src/tab.h
@@ -46,6 +46,7 @@ public:
     auto popup_pane(u64 pane_id, PopupLayout const& popup_layout, Size const& size, CreatePaneArgs args,
                     RenderThread& render_thread) -> di::Result<>;
     auto replace_pane(Pane& pane, CreatePaneArgs args, RenderThread& render_thread) -> di::Result<>;
+    auto pane_by_id(u64 pane_id) -> di::Optional<Pane&>;
 
     void navigate(NavigateDirection direction);
 

--- a/src/ttx.cpp
+++ b/src/ttx.cpp
@@ -25,6 +25,7 @@ struct Args {
     di::Optional<di::TransparentStringView> layout_restore_name;
     di::Optional<di::TransparentStringView> print_terminfo_mode;
     di::Optional<di::TransparentStringView> term;
+    ClipboardMode clipboard_mode { ClipboardMode::System };
     bool replay { false };
     bool headless { false };
     bool print_features { false };
@@ -45,6 +46,7 @@ struct Args {
             .option<&Args::replay>('r', "replay-path"_tsv,
                                    "Replay capture output (file paths are passed via positional args)"_sv)
             .option<&Args::term>('t', "term"_tsv, "Set TERM environment variable (default xterm-ttx)"_sv)
+            .option<&Args::clipboard_mode>({}, "clipboard"_tsv, "Set the clipboard mode"_sv)
             .option<&Args::print_terminfo_mode>({}, "terminfo"_tsv,
                                                 "Print terminfo (mode can be one of: [terminfo, verbose])"_sv)
             .option<&Args::force_local_terminfo>(
@@ -284,7 +286,7 @@ static auto main(Args& args) -> di::Result<void> {
     }
 
     // Setup - render thread.
-    auto render_thread = TRY(RenderThread::create(layout_state, set_done, features));
+    auto render_thread = TRY(RenderThread::create(layout_state, set_done, args.clipboard_mode, features));
     auto _ = di::ScopeExit([&] {
         render_thread->request_exit();
     });

--- a/src/ttx.cpp
+++ b/src/ttx.cpp
@@ -294,8 +294,8 @@ static auto main(Args& args) -> di::Result<void> {
         if (args.headless) {
             return nullptr;
         }
-        return InputThread::create(base_create_pane_args.clone(), di::move(key_binds), layout_state, *render_thread,
-                                   *layout_save_thread);
+        return InputThread::create(base_create_pane_args.clone(), di::move(key_binds), layout_state, features,
+                                   *render_thread, *layout_save_thread);
     }());
     auto _ = di::ScopeExit([&] {
         if (input_thread) {


### PR DESCRIPTION
# Summary

We already supported writing to the system clipboard, but not reading, and additionally the behavior wasn't customizable and didn't consider the different types of clipboards. The new implementation supports both read and writing, and actually reads from the system clipboard when the application requests it, instead of using a local buffer. This makes OSC 52 clipboard mode in Neovim work fully how the user expects.

Additionally, the clipboard behavior is configurable now so that it can be fully disabled or fully local to the ttx instance. By default, we use OSC 52 for reading/writing the clipboard, but users can disable reading the clipboard if desired.

To handle cases where the outer terminal doesn't support reading the clipboard via OSC 52 (wezterm or kitty/ghostty under certain settings), we automatically fallback to local mode when this is detected. We detect terminals which doesn't reply to OSC 52 requests by sending a request on startup, and additionally ignore empty responses (when reading is disabled by kitty (or ourselves), the terminal replies with empty data). In the latter case, the local clipboard state is preserved means that writing and then reading the clipboard works as expected.

Closes #25.

# Check List

- [x] Self-review the code
- [x] Update tests if necessary
- [x] Update docs if necessary
